### PR TITLE
Rename pot_data_locale to po_data_locale in init request

### DIFF
--- a/dist/http/client.js
+++ b/dist/http/client.js
@@ -52,7 +52,7 @@ class Client {
         content.version = this.configuration.service.version;
         content.source_language = this.configuration.sourceLocale;
         translations.forEach(translation => {
-            content[`pot_data_${translation.locale}`] = translation.content;
+            content[`po_data_${translation.locale}`] = translation.content;
             content[`yaml_po_data_${translation.locale}`] = "";
         });
         return content;

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -55,7 +55,7 @@ export class Client {
     content.version = this.configuration.service.version;
     content.source_language = this.configuration.sourceLocale;
     translations.forEach(translation => {
-      content[`pot_data_${translation.locale}`] = translation.content;
+      content[`po_data_${translation.locale}`] = translation.content;
       content[`yaml_po_data_${translation.locale}`] = "";
     });
     return content;


### PR DESCRIPTION
Hi, init failed for me and it was due to the request data sending pot_data instead of po_data. I'm unsure if this is something that translation.io changed on their side within the last 5 years.